### PR TITLE
feat: integrate A18 Pro and 2026 MacBook line-up

### DIFF
--- a/packages/server/src/data/mac_configurations.json
+++ b/packages/server/src/data/mac_configurations.json
@@ -1,0 +1,28 @@
+{
+  "chipsets": ["M1", "M2", "M3", "M4", "M5", "A18"],
+  "variants": ["BASE", "PRO", "MAX", "ULTRA"],
+  "families": [
+    "MacBookAir",
+    "MacBookPro",
+    "MacBookNeo",
+    "iMac",
+    "MacMini",
+    "MacStudio",
+    "MacPro"
+  ],
+  "graphics": ["ULTRA", "HIGH", "MEDIUM", "LOW"],
+  "performance": [
+    "EXCELLENT",
+    "VERY_GOOD",
+    "GOOD",
+    "PLAYABLE",
+    "BARELY_PLAYABLE",
+    "UNPLAYABLE"
+  ],
+  "playMethods": ["NATIVE", "CROSSOVER", "PARALLELS"],
+  "translationLayers": ["DXVK", "DXMT", "D3D_METAL", "NONE"],
+  "softwareVersions": {
+    "CROSSOVER": ["26.0", "25.1.1", "25.1.0", "25.0.1", "25.0", "24.0"],
+    "PARALLELS": ["26", "20", "19"]
+  }
+}

--- a/packages/server/src/schema/index.ts
+++ b/packages/server/src/schema/index.ts
@@ -1,42 +1,22 @@
 import { z } from 'zod';
+import macConfigs from '../data/mac_configurations.json';
 
-export const PlayMethodEnum = z.enum(['NATIVE', 'CROSSOVER', 'PARALLELS']);
-export const TranslationLayerEnum = z.enum([
-  'DXVK',
-  'DXMT',
-  'D3D_METAL',
-  'NONE',
-]);
-export const PerformanceEnum = z.enum([
-  'EXCELLENT',
-  'VERY_GOOD',
-  'GOOD',
-  'PLAYABLE',
-  'BARELY_PLAYABLE',
-  'UNPLAYABLE',
-]);
+// We must assert the array length is at least 1 for z.enum
+export const PlayMethodEnum = z.enum(macConfigs.playMethods as [string, ...string[]]);
+export const TranslationLayerEnum = z.enum(macConfigs.translationLayers as [string, ...string[]]);
+export const PerformanceEnum = z.enum(macConfigs.performance as [string, ...string[]]);
 
-export const MacFamilyEnum = z.enum([
-  'MacBookAir',
-  'MacBookPro',
-  'iMac',
-  'MacMini',
-  'MacStudio',
-  'MacPro',
-]);
-export const GraphicsSettingsEnum = z.enum(['ULTRA', 'HIGH', 'MEDIUM', 'LOW']);
-export const ChipsetEnum = z.enum(['M1', 'M2', 'M3', 'M4', 'M5']);
-export const ChipsetVariantEnum = z.enum(['BASE', 'PRO', 'MAX', 'ULTRA']);
+export const MacFamilyEnum = z.enum(macConfigs.families as [string, ...string[]]);
+export const GraphicsSettingsEnum = z.enum(macConfigs.graphics as [string, ...string[]]);
+export const ChipsetEnum = z.enum(macConfigs.chipsets as [string, ...string[]]);
+export const ChipsetVariantEnum = z.enum(macConfigs.variants as [string, ...string[]]);
 
 export const MacFamily = MacFamilyEnum.Enum;
 export const GraphicsSettings = GraphicsSettingsEnum.Enum;
 export const Chipset = ChipsetEnum.Enum;
 export const ChipsetVariant = ChipsetVariantEnum.Enum;
 
-export const SOFTWARE_VERSIONS = {
-  CROSSOVER: ['26.0', '25.1.1', '25.1.0', '25.0.1', '25.0', '24.0'],
-  PARALLELS: ['26', '20', '19'],
-} as const;
+export const SOFTWARE_VERSIONS = macConfigs.softwareVersions as Readonly<Record<string, string[]>>;
 
 export const SoftwareVersionsSchema = z.object({
   CROSSOVER: z.array(z.string()),

--- a/packages/server/src/scraper/EveryMacScraper.ts
+++ b/packages/server/src/scraper/EveryMacScraper.ts
@@ -45,6 +45,8 @@ export class EveryMacScraper {
       'https://everymac.com/systems/apple/mac-studio/index-macstudio.html',
     MacBookAir:
       'https://everymac.com/systems/apple/macbook-air/all-apple-silicon-macbook-air-models.html',
+    MacBookNeo:
+      'https://everymac.com/systems/apple/macbook-neo/specs/macbook-neo-a18-pro-6-core-cpu-5-core-gpu-13-2026-specs.html',
   };
 
   constructor(private readonly webScraper: WebScraper) {}
@@ -285,10 +287,10 @@ export class EveryMacScraper {
     chip: string;
     variant: ChipsetVariant;
   } {
-    const chipMatch = titleText.match(/"(M\d+)(\s+(Pro|Max|Ultra))?"/i);
+    const chipMatch = titleText.match(/"([AM]\d+)(\s+(Pro|Max|Ultra))?"/i);
 
     return {
-      chip: chipMatch?.[1] || '',
+      chip: chipMatch?.[1]?.toUpperCase() || '',
       variant: (chipMatch?.[3]?.toUpperCase() as ChipsetVariant) || 'BASE',
     };
   }

--- a/packages/server/src/scraper/constant/mac-ram-limits.ts
+++ b/packages/server/src/scraper/constant/mac-ram-limits.ts
@@ -19,6 +19,17 @@ export const RAM_LIMITS: RAMLimitsStructure = {
     M4: {
       [ChipsetVariant.BASE]: 32,
     },
+    M5: {
+      [ChipsetVariant.BASE]: 32,
+    },
+  },
+  MacBookNeo: {
+    M5: {
+      [ChipsetVariant.BASE]: 16,
+    },
+    A18: {
+      [ChipsetVariant.PRO]: 16,
+    },
   },
   MacBookPro: {
     M1: {
@@ -41,6 +52,8 @@ export const RAM_LIMITS: RAMLimitsStructure = {
     },
     M5: {
       [ChipsetVariant.BASE]: 32,
+      [ChipsetVariant.PRO]: 64,
+      [ChipsetVariant.MAX]: 128,
     },
   },
   iMac: {
@@ -60,29 +73,47 @@ export const RAM_LIMITS: RAMLimitsStructure = {
     },
     M2: {
       [ChipsetVariant.BASE]: 24,
+      [ChipsetVariant.PRO]: 32,
     },
     M3: {
       [ChipsetVariant.BASE]: 24,
     },
     M4: {
       [ChipsetVariant.BASE]: 64,
+      [ChipsetVariant.PRO]: 64,
+    },
+    M5: {
+      [ChipsetVariant.BASE]: 64,
+      [ChipsetVariant.PRO]: 128,
     },
   },
   MacStudio: {
+    M1: {
+      [ChipsetVariant.MAX]: 64,
+      [ChipsetVariant.ULTRA]: 128,
+    },
     M2: {
       [ChipsetVariant.MAX]: 96,
+      [ChipsetVariant.ULTRA]: 192,
+    },
+    M3: {
+      [ChipsetVariant.MAX]: 128,
+      [ChipsetVariant.ULTRA]: 512,
+    },
+    M4: {
+      [ChipsetVariant.MAX]: 128,
+      [ChipsetVariant.ULTRA]: 512,
+    },
+  },
+  MacPro: {
+    M2: {
       [ChipsetVariant.ULTRA]: 192,
     },
     M3: {
       [ChipsetVariant.ULTRA]: 512,
     },
     M4: {
-      [ChipsetVariant.MAX]: 128,
-    },
-  },
-  MacPro: {
-    M2: {
-      [ChipsetVariant.ULTRA]: 192,
+      [ChipsetVariant.ULTRA]: 512,
     },
   },
 } as const;


### PR DESCRIPTION
Extracts configurations to JSON and natively supports M4, M5, and MacBook Neo out-of-the-box.