### PR TITLE
Show Machine Family in ReviewCard

### DIFF
--- a/src/modules/review/components/CreateReviewForm/index.tsx
+++ b/src/modules/review/components/CreateReviewForm/index.tsx
@@ -16,10 +16,11 @@ import {
 } from '@/components/ui/tooltip';
 import AuthPrompt from '@/modules/auth/components/AuthPrompt';
 import ScreenshotUpload from '@/modules/review/components/ScreenshotUpload';
-import SelectMacConfiguration, {
+import SelectMacConfiguration from '@/modules/review/components/SelectMacConfiguration';
+import {
   getDeviceIcon,
   getHumanReadableFamily,
-} from '@/modules/review/components/SelectMacConfiguration';
+} from '@/modules/review/utils';
 
 import { useCreateReview } from '../../hooks/useCreateReview';
 import { type ReviewFormProps } from '../../types';

--- a/src/modules/review/components/ReviewCard.tsx
+++ b/src/modules/review/components/ReviewCard.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import ScreenshotDisplay from './ScreenshotDisplay';
 import { type MacSpecification } from '@macgamingdb/server/scraper/EveryMacScraper';
 import { type Performance } from '@macgamingdb/server/schema';
+import { getHumanReadableFamily } from '@/modules/review/utils';
 
 const getPerformanceColor = (performance: Performance) => {
   const colors: Record<Performance, string> = {
@@ -121,6 +122,12 @@ const GameReviewCard = ({
             )}
             {macConfig ? (
               <>
+                <div className="flex justify-between">
+                  <dt className="font-medium">Machine:</dt>
+                  <dd className="font-semibold text-white font-mono">
+                    {getHumanReadableFamily(macConfig.family)}
+                  </dd>
+                </div>
                 <div className="flex justify-between">
                   <dt className="font-medium">Chip:</dt>
                   <dd className="font-semibold text-white font-mono">

--- a/src/modules/review/components/SelectMacConfiguration.tsx
+++ b/src/modules/review/components/SelectMacConfiguration.tsx
@@ -21,6 +21,7 @@ import type { inferRouterOutputs } from '@trpc/server';
 
 import { type AppRouter } from '@macgamingdb/server/routers/_app';
 import { trpc } from '@/lib/trpc/provider';
+import { getDeviceIcon, getHumanReadableFamily } from '@/modules/review/utils';
 
 export type MacConfig =
   inferRouterOutputs<AppRouter>['review']['getMacConfigs'][number];
@@ -30,33 +31,6 @@ interface SelectMacConfigurationProps {
   onSelect: (config: MacConfig) => void;
   onBack: () => void;
 }
-
-export const getDeviceIcon = (family: string) => {
-  return `/images/devices/${family}.svg`;
-};
-
-export const getHumanReadableFamily = (family: string) => {
-  switch (family) {
-    case 'MacBookPro':
-      return 'MacBook Pro';
-    case 'MacBookAir':
-      return 'MacBook Air';
-    case 'MacBookNeo':
-      return 'MacBook Neo';
-    case 'MacBook':
-      return 'MacBook';
-    case 'iMac':
-      return 'iMac';
-    case 'MacMini':
-      return 'Mac mini';
-    case 'MacPro':
-      return 'Mac Pro';
-    case 'MacStudio':
-      return 'Mac Studio';
-    default:
-      return family;
-  }
-};
 
 const MacConfigSkeleton = memo(() => (
   <div className="w-full p-4 rounded-lg border border-border">

--- a/src/modules/review/utils/index.ts
+++ b/src/modules/review/utils/index.ts
@@ -1,1 +1,2 @@
 export { transformPerformanceRating } from './transformPerformanceRating';
+export * from './mac-config';

--- a/src/modules/review/utils/mac-config.ts
+++ b/src/modules/review/utils/mac-config.ts
@@ -1,0 +1,26 @@
+export const getDeviceIcon = (family: string) => {
+  return `/images/devices/${family}.svg`;
+};
+
+export const getHumanReadableFamily = (family: string) => {
+  switch (family) {
+    case 'MacBookPro':
+      return 'MacBook Pro';
+    case 'MacBookAir':
+      return 'MacBook Air';
+    case 'MacBookNeo':
+      return 'MacBook Neo';
+    case 'MacBook':
+      return 'MacBook';
+    case 'iMac':
+      return 'iMac';
+    case 'MacMini':
+      return 'Mac mini';
+    case 'MacPro':
+      return 'Mac Pro';
+    case 'MacStudio':
+      return 'Mac Studio';
+    default:
+      return family;
+  }
+};


### PR DESCRIPTION
Mainly because of cooling, games perform differently on different device families even with the same CPU. Since the machine family is already stored in the database, I think it would be beneficial to show it to user.

This PR:
- Moves `getHumanReadableFamily` to its own file so `ReviewCard` can use it
- Adds machine family to the list of things in ReviewCard