### PR TITLE
Fix publisher string

### DIFF
--- a/src/modules/game/components/GameDetailHeader.tsx
+++ b/src/modules/game/components/GameDetailHeader.tsx
@@ -24,8 +24,8 @@ export function GameDetailHeader({ gameDetails }: GameDetailHeaderProps) {
           <h1 className="text-4xl font-bold text-white mb-2">
             {gameDetails.name || 'Game Information Unavailable'}
           </h1>
-          {gameDetails.release_date && (
-            <p className="text-gray-300">Publisher: {gameDetails.publishers[0]}</p>
+          {gameDetails.publishers && gameDetails.publishers.length > 0 && (
+            <p className="text-gray-300">Publisher: {gameDetails.publishers.join(', ')}</p>
           )}
         </div>
       </div>


### PR DESCRIPTION
The publisher string was shown when the game has a release date, not when it has a publisher. This PR checks if the game has a publisher before showing it and also shows multiple publishers properly.

before and after screenshots:
<img width="1710" height="994" alt="Screenshot 2026-03-28 at 8 38 55 PM" src="https://github.com/user-attachments/assets/20d2c5f7-5df9-4268-ac5e-0c68b35815d0" />
<img width="1710" height="997" alt="Screenshot 2026-03-28 at 8 41 06 PM" src="https://github.com/user-attachments/assets/8113ca36-e80f-4ed4-aa23-56d4f240a4b8" />
