### PR TITLE
fix(web): omit moderationAlertedAt from frontend review type

### DIFF
--- a/src/modules/game/components/ExperienceReportsSection.tsx
+++ b/src/modules/game/components/ExperienceReportsSection.tsx
@@ -10,7 +10,7 @@ import {
 
 type ReviewWithMacConfig = Omit<
   GameReview,
-  'reportCount' | 'lastReportedAt' | 'hiddenAt'
+  'reportCount' | 'lastReportedAt' | 'moderationAlertedAt' | 'hiddenAt'
 > & { macConfig?: MacConfig | null };
 
 interface ExperienceReportsSectionProps {


### PR DESCRIPTION
`moderationAlertedAt` (migration 0009) was added to `GameReview` but not to the `ReviewWithMacConfig` Omit in `ExperienceReportsSection`, so the game-page `reviews` prop required a field the API output doesn't expose — breaking `next build` on the `web` Docker target.

One-line fix: add `moderationAlertedAt` to the omitted internal columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)