### PR TITLE
feat(report): report button + public interactions route

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,10 @@ const nextConfig = {
     return [
       { source: '/api/trpc/:path*', destination: `${apiServerUrl}/trpc/:path*` },
       { source: '/api/rest/:path*', destination: `${apiServerUrl}/rest/:path*` },
+      {
+        source: '/discord/interactions',
+        destination: `${apiServerUrl}/discord/interactions`,
+      },
     ];
   },
 };

--- a/packages/macgamingdb-server/src/@generated/server.ts
+++ b/packages/macgamingdb-server/src/@generated/server.ts
@@ -19,8 +19,8 @@ import { ContributorsPageSchema } from "../modules/contributor/routers/../dtos/c
 import { GameSearchResultSchema } from "../modules/game/routers/../dtos/game-search-result.dto";
 import { CoverArtSchema } from "../modules/game/routers/../dtos/cover-art.dto";
 import { RatingCountsSchema } from "../modules/game/routers/../dtos/rating-counts.dto";
-import { PlayMethodEnum, PerformanceEnum, TranslationLayerEnum, GraphicsSettingsEnum } from "../modules/review/routers/../../../schema/index";
 import { ChipsetEnum, ChipsetVariantEnum } from "../modules/game/routers/../../../schema/index";
+import { PlayMethodEnum, PerformanceEnum, TranslationLayerEnum, GraphicsSettingsEnum } from "../modules/review/routers/../../../schema/index";
 import { GamesPageSchema } from "../modules/game/routers/../dtos/games-page.dto";
 import { SitemapEntrySchema } from "../modules/game/routers/../dtos/sitemap-entry.dto";
 import { GameByIdSchema } from "../modules/game/routers/../dtos/game-by-id.dto";
@@ -30,6 +30,8 @@ import { LibraryStatusSchema } from "../modules/library/routers/../dtos/library-
 import { LibrarySyncResultSchema } from "../modules/library/routers/../dtos/library-sync-result.dto";
 import { LibraryEntrySchema } from "../modules/library/routers/../dtos/library-entry.dto";
 import { OkResultSchema } from "../modules/library/routers/../dtos/ok-result.dto";
+import { ReportResultSchema } from "../modules/report/routers/../dtos/report-result.dto";
+import { ReportReasonSchema } from "../modules/report/routers/../dtos/report-reason.dto";
 import { MyReviewsSchema } from "../modules/review/routers/../dtos/my-reviews.dto";
 import { MacConfigSchema } from "../modules/review/routers/../../mac-config/dtos/mac-config.dto";
 import { UploadUrlSchema } from "../modules/review/routers/../dtos/upload-url.dto";
@@ -122,6 +124,16 @@ const appRouter = t.router({
     unlink: publicProcedure
       .input(z.void())
       .output(OkResultSchema)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
+    }),
+  report: t.router({
+    create: publicProcedure
+      .input(z.object({
+      reviewId: z.string(),
+      reason: ReportReasonSchema.optional(),
+      note: z.string().max(500).optional(),
+    }))
+      .output(ReportResultSchema)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as any)
     }),
   review: t.router({

--- a/src/modules/review/components/ReportReviewDialog.tsx
+++ b/src/modules/review/components/ReportReviewDialog.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from 'macgamingdb-ui/input/Button';
+import { Textarea } from 'macgamingdb-ui/input/Textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'macgamingdb-ui/input/Select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from 'macgamingdb-ui/feedback/Dialog';
+import {
+  REPORT_REASONS,
+  isReportReason,
+  useReportReview,
+  type ReportReason,
+} from '../hooks/useReportReview';
+
+const NOTE_MAX_LENGTH = 500;
+
+export const ReportReviewDialog = ({ reviewId }: { reviewId: string }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [reason, setReason] = useState<ReportReason | undefined>(undefined);
+  const [note, setNote] = useState('');
+  const { submitReport, isSubmitting } = useReportReview({
+    onReported: () => setIsOpen(false),
+  });
+
+  const handleReasonChange = (value: string) => {
+    if (isReportReason(value)) {
+      setReason(value);
+    }
+  };
+
+  const handleSubmit = async () => {
+    await submitReport({
+      reviewId,
+      reason,
+      note: note.trim() || undefined,
+    });
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="text-xs text-gray-400 hover:text-gray-200 transition-colors"
+        >
+          Report
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Report this review</DialogTitle>
+          <DialogDescription>
+            Tell us what looks wrong and a moderator will take a look.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3">
+          <Select value={reason} onValueChange={handleReasonChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Reason" />
+            </SelectTrigger>
+            <SelectContent>
+              {REPORT_REASONS.map((reportReason) => (
+                <SelectItem key={reportReason.value} value={reportReason.value}>
+                  {reportReason.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Textarea
+            value={note}
+            onChange={(event) => setNote(event.target.value)}
+            placeholder="Add details (optional)"
+            maxLength={NOTE_MAX_LENGTH}
+          />
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setIsOpen(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? 'Reporting…' : 'Submit report'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/modules/review/components/ReviewCard.tsx
+++ b/src/modules/review/components/ReviewCard.tsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, CardContent } from 'macgamingdb-ui/display/Card';
 import { Badge } from 'macgamingdb-ui/display/Badge';
 import clsx from 'clsx';
 import { ScreenshotDisplay } from './ScreenshotDisplay';
+import { ReportReviewDialog } from './ReportReviewDialog';
 import { type MacSpecification } from 'macgamingdb-server/modules/mac-config/types/mac-specification.type';
 import { type Performance } from 'macgamingdb-server/schema';
 import { getHumanReadableFamily } from '@/modules/review/utils/getHumanReadableFamily';
@@ -212,6 +213,10 @@ export const ReviewCard = ({
               )}
           </>
         )}
+
+        <div className="flex justify-end pt-3 mt-2 border-t border-white/15">
+          <ReportReviewDialog reviewId={review.id} />
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/modules/review/hooks/useReportReview.ts
+++ b/src/modules/review/hooks/useReportReview.ts
@@ -1,0 +1,43 @@
+import { toast } from 'sonner';
+import { trpc } from '@/modules/trpc/trpc';
+
+export const REPORT_REASONS = [
+  { value: 'spam', label: 'Spam or advertising' },
+  { value: 'offensive', label: 'Offensive content' },
+  { value: 'off_topic', label: 'Off-topic' },
+  { value: 'fake', label: 'Fake or inaccurate' },
+  { value: 'other', label: 'Other' },
+] as const;
+
+export type ReportReason = (typeof REPORT_REASONS)[number]['value'];
+
+export const isReportReason = (value: string): value is ReportReason =>
+  REPORT_REASONS.some((reason) => reason.value === value);
+
+type SubmitReportParams = {
+  reviewId: string;
+  reason?: ReportReason;
+  note?: string;
+};
+
+export const useReportReview = ({
+  onReported,
+}: {
+  onReported?: () => void;
+}) => {
+  const reportMutation = trpc.report.create.useMutation({
+    onSuccess: () => {
+      toast('Thanks — a moderator will review this report.');
+      onReported?.();
+    },
+    onError: (error) => {
+      toast('Could not submit the report. Please sign in and try again.');
+      console.error(error);
+    },
+  });
+
+  const submitReport = (params: SubmitReportParams) =>
+    reportMutation.mutateAsync(params);
+
+  return { submitReport, isSubmitting: reportMutation.isPending };
+};


### PR DESCRIPTION
Adds the missing pieces to make review moderation usable end-to-end:
- **Report button** on ReviewCard → dialog (reason + note) → tRPC `report.create`
- Regenerated tRPC types so `report.create` is client-typed
- **Next rewrite** `/discord/interactions` → internal `api:4000`, exposing the Discord endpoint via `macgamingdb.app` while api stays internal (raw body/signature proxied intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)