### PR TITLE
feat(report): auto-screen new reviews with the moderation LLM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -105,6 +105,7 @@
       "dependencies": {
         "@nestjs/common": "^11.1.28",
         "@nestjs/core": "^11.1.28",
+        "@nestjs/event-emitter": "^3.1.0",
         "@nestjs/platform-express": "^11.1.28",
         "@sniptt/guards": "^0.2.0",
         "@types/express": "^5.0.6",
@@ -765,6 +766,8 @@
     "@nestjs/common": ["@nestjs/common@11.1.28", "", { "dependencies": { "file-type": "21.3.4", "iterare": "1.2.1", "load-esm": "1.0.3", "tslib": "2.8.1", "uid": "2.0.2" }, "peerDependencies": { "class-transformer": ">=0.4.1", "class-validator": ">=0.13.2", "reflect-metadata": "^0.1.12 || ^0.2.0", "rxjs": "^7.1.0" }, "optionalPeers": ["class-transformer", "class-validator"] }, "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ=="],
 
     "@nestjs/core": ["@nestjs/core@11.1.28", "", { "dependencies": { "fast-safe-stringify": "2.1.1", "iterare": "1.2.1", "path-to-regexp": "8.4.2", "tslib": "2.8.1", "uid": "2.0.2" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/microservices": "^11.0.0", "@nestjs/platform-express": "^11.0.0", "@nestjs/websockets": "^11.0.0", "reflect-metadata": "^0.1.12 || ^0.2.0", "rxjs": "^7.1.0" }, "optionalPeers": ["@nestjs/microservices", "@nestjs/platform-express", "@nestjs/websockets"] }, "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ=="],
+
+    "@nestjs/event-emitter": ["@nestjs/event-emitter@3.1.0", "", { "dependencies": { "eventemitter2": "6.4.9" }, "peerDependencies": { "@nestjs/common": "^10.0.0 || ^11.0.0", "@nestjs/core": "^10.0.0 || ^11.0.0" } }, "sha512-DOY/4XBGyIjYyOJKkO6jl1kzFE0ZfX0wV+M2HR5NWymPT9Z0zdCEcZGxTXXkoMRwPtglnvCGJALSjOpXPIcM3g=="],
 
     "@nestjs/platform-express": ["@nestjs/platform-express@11.1.28", "", { "dependencies": { "cors": "2.8.6", "express": "5.2.1", "multer": "2.2.0", "path-to-regexp": "8.4.2", "tslib": "2.8.1" }, "peerDependencies": { "@nestjs/common": "^11.0.0", "@nestjs/core": "^11.0.0" } }, "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA=="],
 
@@ -1975,6 +1978,8 @@
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter2": ["eventemitter2@6.4.9", "", {}, "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="],
 
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 

--- a/packages/macgamingdb-server/package.json
+++ b/packages/macgamingdb-server/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@nestjs/common": "^11.1.28",
     "@nestjs/core": "^11.1.28",
+    "@nestjs/event-emitter": "^3.1.0",
     "@nestjs/platform-express": "^11.1.28",
     "@sniptt/guards": "^0.2.0",
     "@types/express": "^5.0.6",

--- a/packages/macgamingdb-server/src/app.module.ts
+++ b/packages/macgamingdb-server/src/app.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 import { TRPCModule } from 'nestjs-trpc';
 import superjson from 'superjson';
 import { DatabaseModule } from './database/database.module';
@@ -10,6 +11,7 @@ import { ModulesModule } from './modules/modules.module';
 
 @Module({
   imports: [
+    EventEmitterModule.forRoot(),
     DatabaseModule,
     PageRevalidationModule,
     FileStorageModule,

--- a/packages/macgamingdb-server/src/modules/report/listeners/review-created.listener.ts
+++ b/packages/macgamingdb-server/src/modules/report/listeners/review-created.listener.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+  REVIEW_CREATED_EVENT,
+  type ReviewCreatedEvent,
+} from '../../review/events/review-created.event';
+import { ReportService } from '../services/report.service';
+
+@Injectable()
+export class ReviewCreatedListener {
+  constructor(private readonly reportService: ReportService) {}
+
+  @OnEvent(REVIEW_CREATED_EVENT)
+  async handleReviewCreated(event: ReviewCreatedEvent): Promise<void> {
+    await this.reportService.screenNewReview({ reviewId: event.reviewId });
+  }
+}

--- a/packages/macgamingdb-server/src/modules/report/report.module.ts
+++ b/packages/macgamingdb-server/src/modules/report/report.module.ts
@@ -6,6 +6,7 @@ import { DiscordInteractionController } from './controllers/discord-interaction.
 import { DiscordInteractionService } from './drivers/discord/services/discord-interaction.service';
 import { DiscordMessageService } from './drivers/discord/services/discord-message.service';
 import { OpenRouterModerationService } from './drivers/openrouter/services/openrouter-moderation.service';
+import { ReviewCreatedListener } from './listeners/review-created.listener';
 import { ReportRouter } from './routers/report.router';
 import { ReportService } from './services/report.service';
 
@@ -18,6 +19,7 @@ import { ReportService } from './services/report.service';
     AuthMiddleware,
     DiscordMessageService,
     DiscordInteractionService,
+    ReviewCreatedListener,
     { provide: MODERATION_LLM, useClass: OpenRouterModerationService },
   ],
 })

--- a/packages/macgamingdb-server/src/modules/report/services/report.service.ts
+++ b/packages/macgamingdb-server/src/modules/report/services/report.service.ts
@@ -8,6 +8,7 @@ import { gameReviews, users } from '../../../database/schema';
 import { deriveDisplayNameFromEmail } from '../../../engine/utils/derive-display-name-from-email.util';
 import { MODERATION_LLM } from '../constants/moderation-llm.constant';
 import { type ModerationLlm } from '../types/moderation-llm.type';
+import { type ModerationVerdict } from '../dtos/moderation-verdict.dto';
 import { type ReportReason } from '../dtos/report-reason.dto';
 import { DiscordMessageService } from '../drivers/discord/services/discord-message.service';
 import { ReportException } from '../exceptions/report.exception';
@@ -58,46 +59,78 @@ export class ReportService {
       return { success: true, message: 'Report submitted' };
     }
 
-    const [claimed] = await this.db
-      .update(gameReviews)
-      .set({ moderationAlertedAt: new Date().toISOString() })
-      .where(
-        and(
-          eq(gameReviews.id, params.reviewId),
-          isNull(gameReviews.moderationAlertedAt),
-        ),
-      )
-      .returning({ id: gameReviews.id });
-
-    if (!claimed) {
+    if (!(await this.claimAlert(params.reviewId))) {
       return { success: true, message: 'Report submitted' };
     }
 
     try {
-      await this.dispatchModerationAlert({
-        review,
-        reason: params.reason,
-        reporterUserId: params.reporterUserId,
-      });
+      const verdict = await this.judgeReviewOrThrow(review, params.reason);
+      const reporterName = await this.resolveReporterName(params.reporterUserId);
+      await this.postModerationAlert(review, verdict, reporterName, params.reason);
     } catch (error) {
       console.error('Failed to dispatch moderation alert:', error);
-      await this.db
-        .update(gameReviews)
-        .set({ moderationAlertedAt: null })
-        .where(eq(gameReviews.id, params.reviewId));
+      await this.releaseAlert(params.reviewId);
     }
 
     return { success: true, message: 'Report submitted' };
   }
 
-  private async dispatchModerationAlert(params: {
-    review: ReviewWithGame;
-    reason?: ReportReason;
-    reporterUserId: string;
-  }): Promise<void> {
-    const { review } = params;
+  async screenNewReview({ reviewId }: { reviewId: string }): Promise<void> {
+    const review = await this.findReviewWithGame(reviewId);
+    if (!review || isDefined(review.hiddenAt)) {
+      return;
+    }
 
-    const verdict = await this.moderationLlm.judgeReview({
+    let verdict: ModerationVerdict;
+    try {
+      verdict = await this.judgeReviewOrThrow(review);
+    } catch (error) {
+      console.error('Failed to screen new review:', error);
+      return;
+    }
+
+    if (verdict.verdict !== 'flag') {
+      return;
+    }
+
+    if (!(await this.claimAlert(reviewId))) {
+      return;
+    }
+
+    try {
+      await this.postModerationAlert(review, verdict, 'Auto-moderation');
+    } catch (error) {
+      console.error('Failed to post auto-moderation alert:', error);
+      await this.releaseAlert(reviewId);
+    }
+  }
+
+  private async claimAlert(reviewId: string): Promise<boolean> {
+    const [claimed] = await this.db
+      .update(gameReviews)
+      .set({ moderationAlertedAt: new Date().toISOString() })
+      .where(
+        and(
+          eq(gameReviews.id, reviewId),
+          isNull(gameReviews.moderationAlertedAt),
+        ),
+      )
+      .returning({ id: gameReviews.id });
+    return isDefined(claimed);
+  }
+
+  private async releaseAlert(reviewId: string): Promise<void> {
+    await this.db
+      .update(gameReviews)
+      .set({ moderationAlertedAt: null })
+      .where(eq(gameReviews.id, reviewId));
+  }
+
+  private async judgeReviewOrThrow(
+    review: ReviewWithGame,
+    reason?: ReportReason,
+  ): Promise<ModerationVerdict> {
+    return this.moderationLlm.judgeReview({
       game: {
         name: review.game.name ?? 'Unknown game',
         developers: review.game.developers ?? undefined,
@@ -118,11 +151,16 @@ export class ReportService {
         softwareVersion: review.softwareVersion ?? undefined,
         notes: review.notes ?? undefined,
       },
-      reportReason: params.reason,
+      reportReason: reason,
     });
+  }
 
-    const reporterName = await this.resolveReporterName(params.reporterUserId);
-
+  private async postModerationAlert(
+    review: ReviewWithGame,
+    verdict: ModerationVerdict,
+    reporterName: string,
+    reason?: ReportReason,
+  ): Promise<void> {
     await this.discordMessageService.postModerationAlert({
       reviewId: review.id,
       gameName: review.game.name ?? 'Unknown game',
@@ -133,7 +171,7 @@ export class ReportService {
       chipset: `${review.chipset} ${review.chipsetVariant}`,
       performance: review.performance,
       notes: review.notes ?? '',
-      reportReason: params.reason,
+      reportReason: reason,
       reporterName,
       verdict,
     });

--- a/packages/macgamingdb-server/src/modules/review/events/review-created.event.ts
+++ b/packages/macgamingdb-server/src/modules/review/events/review-created.event.ts
@@ -1,0 +1,3 @@
+export const REVIEW_CREATED_EVENT = 'review.created';
+
+export type ReviewCreatedEvent = { reviewId: string };

--- a/packages/macgamingdb-server/src/modules/review/services/review.service.ts
+++ b/packages/macgamingdb-server/src/modules/review/services/review.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { desc, eq, sql } from 'drizzle-orm';
 import { isDefined } from 'macgamingdb-shared/utils/isDefined';
 import { isNonEmptyArray } from '@sniptt/guards';
@@ -24,6 +25,10 @@ import { parseGameRef } from '../../game/utils/parse-game-ref.util';
 import { GameMaterializationService } from '../../game/services/game-materialization.service';
 import { ReviewException } from '../exceptions/review.exception';
 import { PageRevalidationService } from '../../../engine/core-modules/page-revalidation/page-revalidation.service';
+import {
+  REVIEW_CREATED_EVENT,
+  type ReviewCreatedEvent,
+} from '../events/review-created.event';
 
 const ALLOWED_UPLOAD_TYPES = [
   'image/png',
@@ -65,6 +70,7 @@ export class ReviewService {
     private readonly pageRevalidationService: PageRevalidationService,
     private readonly fileStorageService: FileStorageService,
     private readonly gameMaterializationService: GameMaterializationService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private async updateGameAggregatedPerformance(gameId: string): Promise<void> {
@@ -325,6 +331,9 @@ export class ReviewService {
       await this.pageRevalidationService.revalidatePaths({
         paths: [`/games/${game.slug ?? game.id}`, '/contributors'],
       });
+
+      const reviewCreatedEvent: ReviewCreatedEvent = { reviewId: review.id };
+      this.eventEmitter.emit(REVIEW_CREATED_EVENT, reviewCreatedEvent);
 
       return { review };
     } catch (error) {


### PR DESCRIPTION
Every new review is now auto-screened by the moderation LLM (background, off the submit path). Flagged reviews post a Discord alert; clean ones stay silent. Same atomic claim prevents double-posting with the human report path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)