### PR TITLE
fix(report): public URL in Discord alerts + resilient remove handler

### DIFF
--- a/packages/macgamingdb-server/src/modules/report/drivers/discord/services/discord-interaction.service.ts
+++ b/packages/macgamingdb-server/src/modules/report/drivers/discord/services/discord-interaction.service.ts
@@ -82,8 +82,15 @@ export class DiscordInteractionService {
     const { action, reviewId } = parseInteractionCustomId(params.customId);
 
     if (action === REPORT_INTERACTION_ACTION.REMOVE) {
-      await this.reviewService.hideReviewById({ reviewId });
-      return this.updateMessage(`🗑️ Review removed by <@${params.actorId}>`);
+      try {
+        await this.reviewService.hideReviewById({ reviewId });
+        return this.updateMessage(`🗑️ Review removed by <@${params.actorId}>`);
+      } catch (error) {
+        console.error('Failed to hide reported review:', error);
+        return this.updateMessage(
+          `⚠️ Could not remove the review (it may already be gone).`,
+        );
+      }
     }
 
     if (action === REPORT_INTERACTION_ACTION.KEEP) {

--- a/packages/macgamingdb-server/src/modules/report/utils/build-review-url.util.ts
+++ b/packages/macgamingdb-server/src/modules/report/utils/build-review-url.util.ts
@@ -1,4 +1,4 @@
-const DEFAULT_WEB_APP_URL = 'https://macgamingdb.com';
+const PUBLIC_APP_URL = 'https://macgamingdb.app';
 
 export const buildReviewUrl = (gameSlugOrId: string): string =>
-  `${process.env.WEB_APP_URL ?? DEFAULT_WEB_APP_URL}/games/${gameSlugOrId}`;
+  `${process.env.NEXT_PUBLIC_BASE_URL || PUBLIC_APP_URL}/games/${gameSlugOrId}`;


### PR DESCRIPTION
- alert links use the public https URL (not internal http://web:3000 which Discord 400s)
- Remove button handler always responds even if hide fails (no more 'didn't respond in time' on errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)