### PR TITLE
perf(report): background report moderation (fast endpoint)

### DIFF
--- a/packages/macgamingdb-server/src/modules/report/events/report-submitted.event.ts
+++ b/packages/macgamingdb-server/src/modules/report/events/report-submitted.event.ts
@@ -1,0 +1,9 @@
+import { type ReportReason } from '../dtos/report-reason.dto';
+
+export const REPORT_SUBMITTED_EVENT = 'report.submitted';
+
+export type ReportSubmittedEvent = {
+  reviewId: string;
+  reporterUserId: string;
+  reason?: ReportReason;
+};

--- a/packages/macgamingdb-server/src/modules/report/listeners/report-submitted.listener.ts
+++ b/packages/macgamingdb-server/src/modules/report/listeners/report-submitted.listener.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import {
+  REPORT_SUBMITTED_EVENT,
+  type ReportSubmittedEvent,
+} from '../events/report-submitted.event';
+import { ReportService } from '../services/report.service';
+
+@Injectable()
+export class ReportSubmittedListener {
+  constructor(private readonly reportService: ReportService) {}
+
+  @OnEvent(REPORT_SUBMITTED_EVENT)
+  async handleReportSubmitted(event: ReportSubmittedEvent): Promise<void> {
+    await this.reportService.handleReportSubmitted(event);
+  }
+}

--- a/packages/macgamingdb-server/src/modules/report/report.module.ts
+++ b/packages/macgamingdb-server/src/modules/report/report.module.ts
@@ -6,6 +6,7 @@ import { DiscordInteractionController } from './controllers/discord-interaction.
 import { DiscordInteractionService } from './drivers/discord/services/discord-interaction.service';
 import { DiscordMessageService } from './drivers/discord/services/discord-message.service';
 import { OpenRouterModerationService } from './drivers/openrouter/services/openrouter-moderation.service';
+import { ReportSubmittedListener } from './listeners/report-submitted.listener';
 import { ReviewCreatedListener } from './listeners/review-created.listener';
 import { ReportRouter } from './routers/report.router';
 import { ReportService } from './services/report.service';
@@ -20,6 +21,7 @@ import { ReportService } from './services/report.service';
     DiscordMessageService,
     DiscordInteractionService,
     ReviewCreatedListener,
+    ReportSubmittedListener,
     { provide: MODERATION_LLM, useClass: OpenRouterModerationService },
   ],
 })

--- a/packages/macgamingdb-server/src/modules/report/services/report.service.ts
+++ b/packages/macgamingdb-server/src/modules/report/services/report.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import { isDefined } from 'macgamingdb-shared/utils/isDefined';
 import { isNonEmptyString } from '@sniptt/guards';
@@ -11,6 +12,10 @@ import { type ModerationLlm } from '../types/moderation-llm.type';
 import { type ModerationVerdict } from '../dtos/moderation-verdict.dto';
 import { type ReportReason } from '../dtos/report-reason.dto';
 import { DiscordMessageService } from '../drivers/discord/services/discord-message.service';
+import {
+  REPORT_SUBMITTED_EVENT,
+  type ReportSubmittedEvent,
+} from '../events/report-submitted.event';
 import { ReportException } from '../exceptions/report.exception';
 import { buildReviewUrl } from '../utils/build-review-url.util';
 
@@ -31,6 +36,7 @@ export class ReportService {
     @Inject(DRIZZLE_CLIENT) private readonly db: DrizzleDB,
     @Inject(MODERATION_LLM) private readonly moderationLlm: ModerationLlm,
     private readonly discordMessageService: DiscordMessageService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private async findReviewWithGame(reviewId: string) {
@@ -59,20 +65,33 @@ export class ReportService {
       return { success: true, message: 'Report submitted' };
     }
 
-    if (!(await this.claimAlert(params.reviewId))) {
-      return { success: true, message: 'Report submitted' };
-    }
-
-    try {
-      const verdict = await this.judgeReviewOrThrow(review, params.reason);
-      const reporterName = await this.resolveReporterName(params.reporterUserId);
-      await this.postModerationAlert(review, verdict, reporterName, params.reason);
-    } catch (error) {
-      console.error('Failed to dispatch moderation alert:', error);
-      await this.releaseAlert(params.reviewId);
+    if (await this.claimAlert(params.reviewId)) {
+      const event: ReportSubmittedEvent = {
+        reviewId: params.reviewId,
+        reporterUserId: params.reporterUserId,
+        reason: params.reason,
+      };
+      this.eventEmitter.emit(REPORT_SUBMITTED_EVENT, event);
     }
 
     return { success: true, message: 'Report submitted' };
+  }
+
+  async handleReportSubmitted(event: ReportSubmittedEvent): Promise<void> {
+    const review = await this.findReviewWithGame(event.reviewId);
+    if (!review) {
+      await this.releaseAlert(event.reviewId);
+      return;
+    }
+
+    try {
+      const verdict = await this.judgeReviewOrThrow(review, event.reason);
+      const reporterName = await this.resolveReporterName(event.reporterUserId);
+      await this.postModerationAlert(review, verdict, reporterName, event.reason);
+    } catch (error) {
+      console.error('Failed to dispatch moderation alert:', error);
+      await this.releaseAlert(event.reviewId);
+    }
   }
 
   async screenNewReview({ reviewId }: { reviewId: string }): Promise<void> {


### PR DESCRIPTION
reportReview no longer awaits the ~10s LLM+Discord inline — it claims + emits an event and returns immediately; a listener does the work in the background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)