### PR TITLE
fix(report): flag pinned to card bottom + smaller

### DIFF
--- a/src/modules/review/components/ReportReviewDialog.tsx
+++ b/src/modules/review/components/ReportReviewDialog.tsx
@@ -66,7 +66,7 @@ export const ReportReviewDialog = ({ reviewId }: { reviewId: string }) => {
               aria-label="Report review"
               className="text-gray-400 hover:text-gray-200 transition-colors"
             >
-              <Flag size={16} />
+              <Flag size={14} />
             </button>
           </DialogTrigger>
         </TooltipTrigger>

--- a/src/modules/review/components/ReviewCard.tsx
+++ b/src/modules/review/components/ReviewCard.tsx
@@ -68,7 +68,10 @@ export const ReviewCard = ({
   return (
     <Card
       key={review.id}
-      className={clsx('bg-primary-gradient overflow-hidden', className)}
+      className={clsx(
+        'bg-primary-gradient overflow-hidden flex flex-col h-full',
+        className,
+      )}
     >
       {header && header}
       <CardHeader>
@@ -113,7 +116,7 @@ export const ReviewCard = ({
         </div>
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="flex flex-1 flex-col">
         <div className="border-t border-white/15 pt-3 pb-2">
           <dl className="space-y-2 text-sm text-gray-300">
             <div className="flex justify-between">
@@ -217,7 +220,7 @@ export const ReviewCard = ({
         )}
 
         {showReport && (
-          <div className="flex justify-end pt-2 mt-1">
+          <div className="mt-auto flex justify-end pt-3">
             <ReportReviewDialog reviewId={review.id} />
           </div>
         )}


### PR DESCRIPTION
Flag now sits at the bottom of every card (flex-col + mt-auto), fixing the mid-card float on note-less reviews. Icon shrunk 16→14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)