### PR TITLE
fix: /blog returns 500 in production after vinext migration

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -24,6 +24,9 @@ ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 
 COPY --from=builder /app/dist/standalone ./
+# The blog index reads src/app/blog at runtime. Next traced these files into its
+# standalone output; vinext does not, so they are copied explicitly.
+COPY --from=builder /app/src/app/blog ./src/app/blog
 
 EXPOSE 3000
 CMD ["node", "server.js"]


### PR DESCRIPTION
`/blog` is currently **500 in production**. Regression from the vinext migration (#29).

## Cause

The blog index builds its post list by scanning the filesystem at runtime:

```ts
const blogDir = path.join(process.cwd(), 'src/app/blog');
const entries = fs.readdirSync(blogDir, { withFileTypes: true });
```

Next's file tracing spotted that and copied `src/app/blog/**` — including `page.mdx` — into `.next/standalone`. vinext's standalone emitter does no equivalent tracing, so the directory is absent from the image and the read throws.

Verified both halves:

- `ls .next/standalone/src/app/blog` → present (`page.mdx` included)
- `ls dist/standalone/src` → absent

The individual post (`/blog/how-to-play-windows-games-on-mac`) was never affected — it's a compiled route. Only the index scans disk.

## Fix

Copy the directory into the runner image explicitly.

Reproduced the failure by running the standalone server from its own working directory (`/blog` → 500, post → 200), then confirmed the copy restores `/blog` → 200.

## Scope

`src/` has exactly two runtime filesystem reads. The other, `/stats`, reads `/app/stats.json` by absolute path supplied by the deployment and is serving 200 in production — unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)