### PR TITLE
fix(blog): restore article typography and add hero image

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "@eslint/js": "^9.27.0",
         "@mdx-js/rollup": "^3.1.1",
         "@tailwindcss/postcss": "^4.1.7",
+        "@tailwindcss/typography": "^0.5.20",
         "@types/bun": "^1.2.20",
         "@types/node": "^20",
         "@types/react": "^19.2.7",
@@ -993,6 +994,8 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.3", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "postcss": "^8.5.16", "tailwindcss": "4.3.3" } }, "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg=="],
+
+    "@tailwindcss/typography": ["@tailwindcss/typography@0.5.20", "", { "dependencies": { "postcss-selector-parser": "6.0.10" }, "peerDependencies": { "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders" } }, "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
 
@@ -2522,7 +2525,7 @@
 
     "postcss-nested": ["postcss-nested@6.2.0", "", { "dependencies": { "postcss-selector-parser": "^6.1.1" }, "peerDependencies": { "postcss": "^8.2.14" } }, "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ=="],
 
-    "postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+    "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
@@ -3646,6 +3649,8 @@
 
     "postcss-load-config/lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
+    "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
@@ -4079,6 +4084,8 @@
     "@react-email/preview-server/tailwindcss/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
     "@react-email/preview-server/tailwindcss/jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "@react-email/preview-server/tailwindcss/postcss-selector-parser": ["postcss-selector-parser@6.1.4", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ=="],
 
     "@react-email/preview-server/tailwindcss/resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@eslint/js": "^9.27.0",
     "@mdx-js/rollup": "^3.1.1",
     "@tailwindcss/postcss": "^4.1.7",
+    "@tailwindcss/typography": "^0.5.20",
     "@types/bun": "^1.2.20",
     "@types/node": "^20",
     "@types/react": "^19.2.7",

--- a/src/app/blog/how-to-play-windows-games-on-mac/page.mdx
+++ b/src/app/blog/how-to-play-windows-games-on-mac/page.mdx
@@ -1,6 +1,7 @@
 ---
 title: "How to Run Windows Games on Mac With CrossOver or Parallels"
 date: "2026-02-02"
+image: "/images/crossover.png"
 imageGradient: "from-blue-600/70 via-purple-600/60 to-pink-600/70"
 ---
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { Picture } from 'macgamingdb-ui/display/Picture';
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
@@ -75,12 +76,12 @@ const BlogIndexPage = async () => {
                 }`}
               >
                 {post.image ? (
-                  <img
+                  <Picture
                     src={post.image}
                     alt={post.title}
                     loading="lazy"
                     decoding="async"
-                    className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                    className="absolute inset-0 h-full w-full object-contain p-6 transition-transform duration-300 group-hover:scale-105"
                   />
                 ) : (
                   <div className="absolute inset-0 flex items-center justify-center">

--- a/src/app/tailwind.css
+++ b/src/app/tailwind.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
 
+@plugin '@tailwindcss/typography';
+
 @font-face {
   font-family: 'Geist';
   font-style: normal;
@@ -13,6 +15,7 @@
 }
 
 @source '../../packages/macgamingdb-ui/src';
+@source './blog/**/*.mdx';
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Blog post rendered unstyled and the index card showed a placeholder icon.

## Typography

The article is wrapped in `class="prose prose-invert"`, but `@tailwindcss/typography` was never a dependency, and Tailwind v4 requires an explicit `@plugin` directive in CSS. Those classes generated **zero** rules — confirmed by grepping the built stylesheet from both the Next and vinext builds: `.prose` absent in each.

Installs the plugin and declares `@plugin '@tailwindcss/typography'`. Built CSS grows ~14 KB and now contains `.prose` / `--tw-prose`.

The MDX itself was always parsed correctly — 2 h1, 10 h2, 15 h3, 66 p, 3 GFM tables with 44 cells, 25 links, no leaking markdown syntax. It was purely a missing-stylesheet problem.

## Hero image

The post's frontmatter had `title`, `date` and `imageGradient` but no `image`, so the card fell through to the placeholder SVG branch. Adds `image: "/images/crossover.png"` (existing on-topic asset) and renders it via `Picture`, so it serves AVIF with PNG fallback like every other image on the site.

Swap the asset if you'd prefer a different one — it's one frontmatter line.

## Also

Added `@source './blog/**/*.mdx'` so Tailwind scans MDX for class names; the gradient utilities are declared only inside frontmatter.

## Verified

Ran the standalone build from its own working directory (matching the container):

- `.prose` and `--tw-prose` present in shipped CSS
- index renders `<picture>` with AVIF source, `<img>` fallback `/images/crossover.png`
- gradient utility still generated
- `/images/crossover.avif` → 200 `image/avif`, `.png` → 200 `image/png`
- `tsc` clean, 42/42 tests, AVIF sibling check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)