### PR TITLE
ci: drop the Next.js build, typecheck explicitly instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,14 +67,14 @@ jobs:
       - name: Build workspace packages
         run: bun run build:api
 
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
       - name: Test
         run: bun run test
 
-      - name: Build (vinext)
+      - name: Build
         run: bun run build:vinext
-
-      - name: Build (Next.js)
-        run: bun run build
 
   deploy:
     name: Deploy to Coolify


### PR DESCRIPTION
Production builds with vinext, so running `next build` afterwards only proved that a pipeline nothing deploys still works. It cost about 20s per run and warned about a missing build cache it was never going to have.

It was, however, the only thing typechecking src/ in CI: build:api covers the workspace packages, and vinext build does not typecheck. So it is replaced with `tsc --noEmit` rather than simply removed, which is faster and states the intent.

Removing it also drops the stale .next/types noise, since nothing generates that directory in CI any more.

Next stays a dependency: src/ imports types such as Metadata from it.