### PR TITLE
fix(steam): restore the Steam connection routes under vinext

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -51,6 +51,7 @@
         "react": "^19.2.3",
         "react-dom": "^19.2.3",
         "react-server-dom-webpack": "^19.2.8",
+        "reflect-metadata": "^0.2.2",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "resend": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "next dev --turbopack",
-    "dev:server": "bun run build:api && env $(grep -v \"^#\" .env.local | xargs) node --watch packages/macgamingdb-server/dist/main.js",
+    "dev:server": "bun run build:api && node --env-file=.env.local --watch packages/macgamingdb-server/dist/main.js",
     "db:push": "bunx drizzle-kit push",
     "db:push:prod": "NODE_ENV=production bunx --env-file=.env.prod drizzle-kit push",
     "db:generate": "bunx drizzle-kit generate",
@@ -85,6 +85,7 @@
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "react-server-dom-webpack": "^19.2.8",
+    "reflect-metadata": "^0.2.2",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "resend": "^4.2.0",

--- a/src/app/api/connections/steam/app-callback/route.ts
+++ b/src/app/api/connections/steam/app-callback/route.ts
@@ -1,3 +1,7 @@
+// @nestjs/common requires reflect-metadata at load, but declares it as a peer
+// dependency, so bundler tracing does not follow it. Importing it here keeps it
+// in the standalone output.
+import 'reflect-metadata';
 import { type NextRequest, NextResponse } from 'next/server';
 import { and, eq } from 'drizzle-orm';
 import { createDrizzleClient } from 'macgamingdb-server/database';

--- a/src/app/api/connections/steam/callback/route.ts
+++ b/src/app/api/connections/steam/callback/route.ts
@@ -1,3 +1,7 @@
+// @nestjs/common requires reflect-metadata at load, but declares it as a peer
+// dependency, so bundler tracing does not follow it. Importing it here keeps it
+// in the standalone output.
+import 'reflect-metadata';
 import { type NextRequest, NextResponse } from 'next/server';
 import { headers, cookies } from 'next/headers';
 import { and, eq } from 'drizzle-orm';

--- a/src/app/api/connections/steam/start/route.ts
+++ b/src/app/api/connections/steam/start/route.ts
@@ -1,3 +1,7 @@
+// @nestjs/common requires reflect-metadata at load, but declares it as a peer
+// dependency, so bundler tracing does not follow it. Importing it here keeps it
+// in the standalone output.
+import 'reflect-metadata';
 import { NextResponse } from 'next/server';
 import { headers, cookies } from 'next/headers';
 import { createDrizzleClient } from 'macgamingdb-server/database';


### PR DESCRIPTION
## Summary
Steam account linking has been returning a 500 in production since the vinext migration, for both the website's connect button and the iOS app.

The three Steam OpenID routes import NestJS services. `@nestjs/common` requires `reflect-metadata` at module load but declares it as a **peer** dependency, so vinext's tracing never followed it into the standalone output. Next's file tracing did — hence the regression.

```
[vinext] Server error: Error: Cannot find module 'reflect-metadata'
Require stack:
- /app/node_modules/@nestjs/common/index.js
```

## Changes
- Import `reflect-metadata` explicitly in the three routes that pull in decorated Nest classes, so it is traced into `dist/standalone`
- Declare `reflect-metadata` as a direct dependency instead of relying on hoisting
- Fix `dev:server`, which built its env with `env $(grep ... | xargs)` and split `APPLE_PRIVATE_KEY` on its spaces (`env: PRIVATE: No such file or directory`). Node's `--env-file` handles quoted values.

## Verification
- Confirmed `reflect-metadata` is present in `dist/standalone/node_modules/` after build
- Booted the standalone build locally: `/api/connections/steam/app-callback` returns `307 → macgamingdb://steam-link?status=error&error=state-missing` instead of a 500
- End-to-end Steam link completed from the iOS app against the local stack
- `tsc` clean (root + server), 42/42 vitest

Only these three routes import Nest service classes; the rest of the app imports types, which erase at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)