### PR TITLE
fix(build): copy peer dependencies into the vinext standalone output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -170,6 +170,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "vinext@1.0.0-beta.4": "patches/vinext@1.0.0-beta.4.patch",
+  },
   "overrides": {
     "@better-auth/expo": "1.4.13",
     "@radix-ui/react-accordion": "1.2.16",

--- a/package.json
+++ b/package.json
@@ -134,5 +134,8 @@
     "better-auth": "1.4.7",
     "@better-auth/expo": "1.4.13"
   },
-  "type": "module"
+  "type": "module",
+  "patchedDependencies": {
+    "vinext@1.0.0-beta.4": "patches/vinext@1.0.0-beta.4.patch"
+  }
 }

--- a/patches/vinext@1.0.0-beta.4.patch
+++ b/patches/vinext@1.0.0-beta.4.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/build/standalone.js b/dist/build/standalone.js
+index 8114e3c2d14e6cde055a87474f1449cf3ec1d801..d0f64b84db15cfcea6aaef039888a71f9185b679 100644
+--- a/dist/build/standalone.js
++++ b/dist/build/standalone.js
+@@ -7,13 +7,18 @@ import nodePath from "node:path";
+ function readPackageJson(packageJsonPath) {
+ 	return JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+ }
+-/** Returns both `dependencies` and `optionalDependencies` keys — the full set of potential runtime deps. */
++/** Returns `dependencies`, `optionalDependencies` and `peerDependencies` keys — the full set of potential runtime deps. */
+ function runtimeDeps(pkg) {
+ 	return Object.keys({
+ 		...pkg.dependencies,
+-		...pkg.optionalDependencies
++		...pkg.optionalDependencies,
++		...pkg.peerDependencies
+ 	});
+ }
++/** Peers are resolved best-effort: an uninstalled peer is one the app does not use. */
++function peerDeps(pkg) {
++	return new Set(Object.keys(pkg.peerDependencies ?? {}));
++}
+ /**
+ * Read the externals manifest written by the `vinext:server-externals-manifest`
+ * Vite plugin during the production build.
+@@ -94,10 +99,11 @@ function copyPackageAndRuntimeDeps(root, targetNodeModulesDir, initialPackages,
+ 		const packageResolver = createRequire(realPackageJsonPath);
+ 		const pkg = readPackageJson(realPackageJsonPath);
+ 		const optionalDeps = new Set(Object.keys(pkg.optionalDependencies ?? {}));
++		const peers = peerDeps(pkg);
+ 		for (const depName of runtimeDeps(pkg)) if (!copied.has(depName)) queue.push({
+ 			packageName: depName,
+ 			resolver: packageResolver,
+-			optional: optionalDeps.has(depName)
++			optional: optionalDeps.has(depName) || peers.has(depName)
+ 		});
+ 	}
+ 	return [...copied];


### PR DESCRIPTION
## Summary
Steam linking still 500'd in production after #39. That PR added `reflect-metadata`, but only moved the failure to the next missing package:

```
[vinext] Server error: Error: Cannot find module 'rxjs/operators'
requireStack: [ '/app/node_modules/@nestjs/common/serializer/class-serializer.interceptor.js' ]
```

Root cause: vinext walks the dependency closure of each external package when assembling `dist/standalone/node_modules`, but reads only `dependencies` and `optionalDependencies`. NestJS declares its runtime requirements as **peers**, so none of them were ever copied. Naming packages one at a time is unbounded; this fixes the class.

## Change
Patch `runtimeDeps` to include `peerDependencies`, and mark peers optional in the copy queue so an uninstalled peer is skipped instead of failing the build — an absent peer is one the app doesn't use.

`@nestjs/common` declares four peers. `reflect-metadata` and `rxjs` are installed and now get copied; `class-validator` and `class-transformer` are marked optional upstream, aren't installed, and are correctly skipped.

vinext exposes no `outputFileTracingIncludes` equivalent, so there's no config-level alternative.

## Verification
Previous local checks were invalid: running `dist/standalone/server.js` from inside the repo lets Node walk up into the root `node_modules`, masking every missing dependency. Production has no parent to walk to — which is why local passed and prod failed.

Re-verified by copying the standalone output to a directory **outside** the repo and running it there:

- `reflect-metadata`, `rxjs`, `@nestjs/common` present; `class-transformer` correctly absent
- `/api/connections/steam/app-callback` → `307 → macgamingdb://steam-link?status=error&error=state-missing`
- zero `Cannot find module` errors in the server log

`tsc` clean, 42/42 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)