### PR TITLE
ci: enforce lint and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Build workspace packages
         run: bun run build:api
 
+      - name: Lint
+        run: bun run lint
+
+      - name: Check formatting
+        run: bun run format:check
+
       - name: Typecheck
         run: bunx tsc --noEmit
 


### PR DESCRIPTION
## Summary
CI ran `build:api`, `tsc`, `test` and `build:vinext` — but never linted. That's how 713 ESLint errors accumulated without anything ever failing.

Now that #42 landed oxlint + oxfmt, the check costs essentially nothing:

```
bun run lint          PASS   0.09s
bun run format:check  PASS   0.31s
```

## Change
Two steps added after the workspace build, so lint failures surface before the slower typecheck and build:

```yaml
- name: Lint
  run: bun run lint

- name: Check formatting
  run: bun run format:check
```

Verified both pass against current master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)