### PR TITLE
feat(web): add the iOS Smart App Banner

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,10 @@ export const metadata: Metadata = {
       { url: '/favicon.svg', type: 'image/svg+xml' },
     ],
   },
+  itunes: {
+    appId: '6777818274',
+    appArgument: 'https://macgamingdb.app',
+  },
 };
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## What

MGDB is live on the App Store ([id 6777818274](https://apps.apple.com/us/app/mgdb/id6777818274)), so surface it to mobile visitors with Apple's Smart App Banner.

Added via Next's Metadata API in `src/app/layout.tsx`:

```ts
itunes: {
  appId: '6777818274',
  appArgument: 'https://macgamingdb.app',
},
```

Which renders on every page:

```html
<meta name="apple-itunes-app" content="app-id=6777818274, app-argument=https://macgamingdb.app">
```

The app ID was verified against the iTunes lookup API — it resolves to MGDB v1.0.

## Caveats

- The banner **only renders in Safari on iOS and iPadOS**. macOS Safari, Chrome and Firefox ignore it, so desktop visitors still need a visible link somewhere.
- Once a user dismisses it, it stays dismissed for the site. That is Safari's behaviour and cannot be overridden.
- `app-argument` points at the site root rather than the current page, since the app does not claim per-page universal links yet. Easy to make per-page later.

## Verified

`bunx tsc --noEmit` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)