### PR TITLE
infra: run libSQL as a Coolify-managed compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,18 @@
 services:
+  libsql:
+    image: ghcr.io/tursodatabase/libsql-server:fc98e19
+    environment:
+      - SQLD_NODE=primary
+      - SQLD_AUTH_JWT_KEY=${SQLD_AUTH_JWT_KEY}
+    volumes:
+      - /home/opc/sqld-data:/var/lib/sqld
+    restart: unless-stopped
   api:
     build:
       context: .
       dockerfile: Dockerfile.api
+    depends_on:
+      - libsql
     environment:
       - SERVER_PORT=4000
       - LIBSQL_DATABASE_URL=${LIBSQL_DATABASE_URL}


### PR DESCRIPTION
Runs the turso `libsql-server` as a `libsql` service in the Coolify compose stack, reusing the existing `/home/opc/sqld-data` volume, instead of a loose standalone `docker run` container.

- `api` gains `depends_on: [libsql]`
- DB reached internally at `http://libsql:8080` (env `LIBSQL_DATABASE_URL` already updated in Coolify; `SQLD_AUTH_JWT_KEY` added)
- Data volume unchanged, so no data movement

Context: the standalone container crash-looped after an unclean poweroff today; moving it into the stack lets Coolify manage its lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)